### PR TITLE
Updated to use legacy openfl.utils.JNI for lime legacy compatibility

### DIFF
--- a/extension/share/Share.hx
+++ b/extension/share/Share.hx
@@ -15,7 +15,11 @@ typedef ShareQueryResult = {
 class Share {
 
 	#if android
-	private static var __share : String->String->String->String->String->Void=lime.system.JNI.createStaticMethod("shareex/ShareEx", "share", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V");
+		#if (!lime_legacy)
+		private static var __share : String->String->String->String->String->Void=lime.system.JNI.createStaticMethod("shareex/ShareEx", "share", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V");
+		#else
+		private static var __share : String->String->String->String->String->Void=openfl.utils.JNI.createStaticMethod("shareex/ShareEx", "share", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V");
+		#end
 	#elseif ios
 	private static var __share : String->String->String->String->Void=cpp.Lib.load("openflShareExtension","share_do",4);
 	#elseif blackberry


### PR DESCRIPTION
This allows the extension to be used in HaxeFlixel Android projects.